### PR TITLE
Fix error when entry/@colname doesn't match a colspec/@colname (Issue #3) 

### DIFF
--- a/source/cals-table-functions.xsl
+++ b/source/cals-table-functions.xsl
@@ -93,7 +93,7 @@
     <xd:return>It's position or index</xd:return>
   </xd:doc>
   <xsl:function name="cals:colnum" as="xs:integer">
-    <xsl:param name="col" as="element()"/> <!-- element is a colspec -->
+    <xsl:param name="col"/> <!-- element is a colspec -->
     <xsl:sequence select="if (exists($col/@colnum)) then $col/@colnum else 
       if ($col/preceding-sibling::*:colspec) then cals:colnum($col/preceding-sibling::*:colspec[1]) + 1 else 1"/>
   </xsl:function>


### PR DESCRIPTION
Addressing issue #3. It turns out that if we don't demand that the input of cals:colnum be an element, then the empty sequence error goes away when the entry/@colname is incorrect. The rules then correctly report the error. 