### PR TITLE
Don't assume @namest/@nameend lookups will succeed

### DIFF
--- a/source/cals.sch
+++ b/source/cals.sch
@@ -85,7 +85,7 @@
         select="saxon:path()"/>') CALS-T2R1D</assert>
     </rule>
     <rule context="*:entry">
-      <assert test="if (exists(@namest) and exists(@nameend)) then 
+      <assert test="if (exists(@namest) and exists(@nameend) and cals:lookup(., @namest) and cals:lookup(., @nameend)) then
         cals:colnum(cals:lookup(., @namest)) lt cals:colnum(cals:lookup(., @nameend))
         else true()">In <xsl:value-of 
           select="saxon:path()"/> the column specified by the namest attribute (<xsl:value-of


### PR DESCRIPTION
When I validate the following XML file, I receive the error "An empty sequence is not allowed as the first argument of cals:colnum()". Adding a test to confirm that cals:lookup doesn't return an emtpy sequence causes the schematron to produce the errors that I expect:

* Description: /chapter/informaltable[1]/tgroup[1]/tbody[1]/row[2]/entry[1] has no in-scope colspec definition for the nameend reference 'c4' CALS-T10R4A
Start location: 29:45
* Description: Entry (/chapter/informaltable[1]/tgroup[1]/tbody[1]/row[2]/entry[1]) specifies a start column (column 0) which is to the left (or less than in numeric terms) of the position it would be placed by default (column 1)
Start location: 29:45

```xml
<?xml version="1.0" encoding="UTF-8"?>
<chapter
  xmlns="http://docbook.org/ns/docbook" xml:id="foo"
  version="5.0">
    <title>Lorem dolor amet adipisicing sed</title>
    <informaltable xml:id="accessor.ir_smpcf" xreflabel="ir_smpcf" pgwide="1">
      <?dbfo keep-together="always"?>
      <tgroup cols="4">
        <colspec colwidth=" 8*" colname="c0" align="left"/>
        <colspec colwidth=" 6*" colname="c1" align="center"/>
        <colspec colwidth=" 6*" colname="c2" align="center"/>
        <colspec colwidth=" 6*" colname="c3" align="center"/>
        <tbody>
          <row rowsep="0" valign="middle">
            <entry namest="c0">
              <para>Lorem</para>
            </entry>
            <entry namest="c1" colsep="0">
              <para/>
            </entry>
            <entry namest="c2" colsep="0">
              <para>Lorem</para>
            </entry>
            <entry namest="c3" colsep="1">
              <para>Lorem</para>
            </entry>
          </row>
          <row rowsep="1">
            <entry namest="c0" nameend="c4">
              <?db-font-size 6pt?>
              <para/>
            </entry>
          </row>
        </tbody>
      </tgroup>
    </informaltable>
</chapter>
```